### PR TITLE
Add support for iTerm

### DIFF
--- a/OpenInTerminal/OTOpenInTerminal.m
+++ b/OpenInTerminal/OTOpenInTerminal.m
@@ -85,7 +85,15 @@ static NSArray *supportFileFormats = nil;
 {
     if(projectPath)
     {
-        [NSTask launchedTaskWithLaunchPath:@"/usr/bin/open" arguments:@[@"-a", @"/Applications/Utilities/Terminal.app", projectPath]];
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        
+        NSString *pathForFile = @"/Applications/iTerm.app";
+        
+        if (![fileManager fileExistsAtPath:pathForFile]) {
+            pathForFile = @"/Applications/Utilities/Terminal.app";
+        }
+        
+        [NSTask launchedTaskWithLaunchPath:@"/usr/bin/open" arguments:@[@"-a", pathForFile, projectPath]];
     }
 }
 


### PR DESCRIPTION
Prefer iTerm.app over the default Terminal.app in Mac OS X.